### PR TITLE
fix: add `/enum` export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.1",
   "description": "A BACnet® protocol stack written in pure TypeScript.",
   "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./enum": "./dist/lib/enum.js"
+  },
   "dependencies": {
     "debug": "^4.3.4",
     "iconv-lite": "^0.6.3"


### PR DESCRIPTION
Include an export for the `/enum` module in the package.json file to enhance module accessibility.