### PR TITLE
fix(GetEventInformation): decoding error ERR_OUT_OF_RANGE if object identifier is not provided

### DIFF
--- a/src/lib/services/GetEventInformation.ts
+++ b/src/lib/services/GetEventInformation.ts
@@ -20,15 +20,15 @@ export default class GetEventInformation extends BacnetAckService {
 		let len = 0
 		const result = baAsn1.decodeTagNumberAndValue(buffer, offset + len)
 		len += result.len
-    let lastReceivedObjectId: BACNetObjectID | null = null;
-    if (offset + len < buffer.length) {
-  		const decodedValue = baAsn1.decodeObjectId(buffer, offset + len)
-  		len += decodedValue.len
-      lastReceivedObjectId = {
-        type: decodedValue.objectType,
-        instance: decodedValue.instance,
-      }
-    }
+		let lastReceivedObjectId: BACNetObjectID | null = null;
+		if (offset + len < buffer.length) {
+			const decodedValue = baAsn1.decodeObjectId(buffer, offset + len)
+			len += decodedValue.len
+			lastReceivedObjectId = {
+				type: decodedValue.objectType,
+				instance: decodedValue.instance,
+			}
+		}
 		return { len, lastReceivedObjectId }
 	}
 

--- a/src/lib/services/GetEventInformation.ts
+++ b/src/lib/services/GetEventInformation.ts
@@ -20,7 +20,12 @@ export default class GetEventInformation extends BacnetAckService {
 		let len = 0
 		const result = baAsn1.decodeTagNumberAndValue(buffer, offset + len)
 		len += result.len
-		let lastReceivedObjectId: BACNetObjectID | null = null;
+		let lastReceivedObjectId: BACNetObjectID | null = null
+		// According to clause 13.12 of the BACnet specification, requests for
+		// the `getEventInformation` service may include the optional parameter
+		// "Last Received Object Identifier" used by client to specify the last
+		// Object Identifier received in a preceding "GetEventInformation"
+		// response.
 		if (offset + len < buffer.length) {
 			const decodedValue = baAsn1.decodeObjectId(buffer, offset + len)
 			len += decodedValue.len

--- a/src/lib/services/GetEventInformation.ts
+++ b/src/lib/services/GetEventInformation.ts
@@ -20,15 +20,16 @@ export default class GetEventInformation extends BacnetAckService {
 		let len = 0
 		const result = baAsn1.decodeTagNumberAndValue(buffer, offset + len)
 		len += result.len
-		const decodedValue = baAsn1.decodeObjectId(buffer, offset + len)
-		len += decodedValue.len
-		return {
-			len,
-			lastReceivedObjectId: {
-				type: decodedValue.objectType,
-				instance: decodedValue.instance,
-			},
-		}
+    let lastReceivedObjectId: BACNetObjectID | null = null;
+    if (offset + len < buffer.length) {
+  		const decodedValue = baAsn1.decodeObjectId(buffer, offset + len)
+  		len += decodedValue.len
+      lastReceivedObjectId = {
+        type: decodedValue.objectType,
+        instance: decodedValue.instance,
+      }
+    }
+		return { len, lastReceivedObjectId }
 	}
 
 	public static encodeAcknowledge(

--- a/test/integration/get-event-information.spec.ts
+++ b/test/integration/get-event-information.spec.ts
@@ -35,9 +35,11 @@ test.describe('bacnet - getEventInformation integration', () => {
 			// Ecostruxture Building Operation (EBO). I've opted to inject an
 			// external payload rather than using this very library to generate
 			// the request as the latter could hide or confuse different issues.
-			/* eslint-disable */
-			// @ts-ignore
-			client._transport.emit('message', Buffer.from('810a000a01040205431d', 'hex'));
+			client['_transport'].emit(
+				'message',
+				Buffer.from('810a000a01040205431d', 'hex'),
+				'127.0.0.1:8080',
+			)
 		})
 	})
 })

--- a/test/integration/get-event-information.spec.ts
+++ b/test/integration/get-event-information.spec.ts
@@ -20,4 +20,24 @@ test.describe('bacnet - getEventInformation integration', () => {
 			)
 		})
 	})
+	test('should correctly parse a request without the optional "Last Received Object Identifier" parameter (see clause 13.12 of the spec)', (t) => {
+		return new Promise((resolve) => {
+			const client = new utils.BacnetClient({ apduTimeout: 200 })
+			client.on('getEventInformation', (req) => {
+				assert.deepStrictEqual(req.payload, {
+					len: 1,
+					lastReceivedObjectId: null,
+				})
+				client.close()
+				resolve()
+			})
+			// Test payload is taken as-is from a request made by Schneider's
+			// Ecostruxture Building Operation (EBO). I've opted to inject an
+			// external payload rather than using this very library to generate
+			// the request as the latter could hide or confuse different issues.
+			/* eslint-disable */
+			// @ts-ignore
+			client._transport.emit('message', Buffer.from('810a000a01040205431d', 'hex'));
+		})
+	})
 })


### PR DESCRIPTION
This PR fixes the decoding error `ERR_OUT_OF_RANGE` triggered whenever a `GetEventInformation` request is received that does not have the optional `Last Received Object Identifier` parameter:

```
bacnet:client:debug Exception thrown when processing message: RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 6. Received 11
    at boundsError (node:internal/buffer:88:9)
    at Buffer.readUInt32BE (node:internal/buffer:311:5)
    at Buffer.readUIntBE (node:internal/buffer:269:17)
    at decodeUnsigned (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/asn1.js:116:23)
    at Object.decodeObjectId (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/asn1.js:658:47)
    at GetEventInformation.decode (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/services/GetEventInformation.js:52:37)
    at BACnetClient._processServiceRequest (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/client.js:256:50)
    at BACnetClient._handlePdu (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/client.js:347:26)
    at BACnetClient._handleNpdu (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/client.js:376:14)
    at BACnetClient._receiveData (/Users/jacoscaz/Projects/bacnet-device/node_modules/@innovation-system/node-bacnet/dist/lib/client.js:398:22) {
  code: 'ERR_OUT_OF_RANGE'
```

I believe that this error is due to the mistaken assumption that the `Last Received Object Identifier` is a mandatory parameter, thus guaranteed to be there, whereas the specification flags it as optional:

![Screenshot 2025-06-10 at 11 07 22](https://github.com/user-attachments/assets/ed909ae6-34a1-413d-979f-e5496db5955d)

Thus, the code doesn't check for whether it has already reached the end of the buffer before calling `decodeObjectId()`.

This error came up while testing my own [`bacnet-device`](https://github.com/jacoscaz/bacnet-device) library, which builds upon this one,  against Schneider's EBO platform and can be easily reproduced with payload `810a000a01040205431d` as follows:

```typescript

import bacnet from "@innovation-system/node-bacnet";

const { default: BACnetClient } = bacnet;

const client = new BACnetClient();

// @ts-ignore
client._transport.emit('message', Buffer.from('810a000a01040205431d', 'hex'));
``` 

See:

- Clause 5.6 of the spec for the description of the tabular format used to detail the parameters of service primitives
- Clause 13.12 of the spec for the structure of the `GetEventInformation` service primitive

I should also add that I'm quite new to BACnet in general; take my words with a few grains of salt.