### PR TITLE
feat: scaffolding for stronger typing of ApplicationData values

### DIFF
--- a/src/lib/asn1.ts
+++ b/src/lib/asn1.ts
@@ -21,7 +21,6 @@ import {
 	CalendarDateRange,
 	CalendarWeekDay,
 	Calendar,
-	AppData,
 	DeviceObjPropertyRef,
 	ReadAccessSpec,
 	CovSubscription,
@@ -1428,9 +1427,9 @@ const bacappDecodeData = (
 	maxLength: number,
 	tagDataType: number,
 	lenValueType: number,
-): AppData => {
+): ApplicationData => {
 	let result
-	const value: AppData = {
+	const value: ApplicationData = {
 		len: 0,
 		type: tagDataType,
 		value: null,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -144,11 +144,8 @@ export interface ObjectId {
 	instance: number
 }
 
-export interface ApplicationData {
+export interface ApplicationData extends BACNetAppData {
 	len: number
-	type: ApplicationTag
-	value: any
-	encoding?: number
 }
 
 export interface BACNetReadAccess {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,10 @@ import {
 	ObjectType,
 	PropertyIdentifier,
 	TimeStamp,
+	EngineeringUnits,
+	DeviceStatus,
+	Segmentation,
+	Reliability,
 } from './enum'
 
 export interface EncodeBuffer {
@@ -65,11 +69,13 @@ export interface BACNetBitString {
 	value: number[]
 }
 
+export interface BACNetRecipient {
+	network: number
+	address: number[]
+}
+
 export interface BACNetCovSubscription {
-	recipient: {
-		network: number
-		address: number[]
-	}
+	recipient: BACNetRecipient
 	subscriptionProcessId: number
 	monitoredObjectId: BACNetObjectID
 	monitoredProperty: BACNetPropertyID
@@ -101,10 +107,71 @@ export interface BACNetDevObjRef {
 	deviceIndentifier: BACNetObjectID
 }
 
-export interface BACNetAppData {
-	type: ApplicationTag
-	value: any
+/**
+ * TODO: when the time comes, drop the default value for the `Tag` generic
+ *       parameter to enforce type safety everywhere throughout the library.
+ */
+export interface BACNetAppData<
+	Tag extends ApplicationTag = ApplicationTag,
+	Type extends
+		ApplicationTagValueTypeMap[Tag] = ApplicationTagValueTypeMap[Tag],
+> {
+	type: Tag
+	value: Type
 	encoding?: number
+}
+
+/**
+ * Map between BACnet Application Tags and TypeScript types.
+ *
+ * This interface defines the mapping between each BACnet ApplicationTag
+ * and its corresponding TypeScript type. This mapping is used throughout
+ * the library to ensure type safety when working with BACnet values.
+ *
+ * Entries mapping to the `any` type are yet to be typed.
+ */
+export interface ApplicationTagValueTypeMap {
+	[ApplicationTag.NULL]: null
+	[ApplicationTag.BOOLEAN]: boolean
+	[ApplicationTag.UNSIGNED_INTEGER]: number
+	[ApplicationTag.SIGNED_INTEGER]: number
+	[ApplicationTag.REAL]: number
+	[ApplicationTag.DOUBLE]: number
+	[ApplicationTag.OCTET_STRING]: any
+	[ApplicationTag.CHARACTER_STRING]: string
+	[ApplicationTag.BIT_STRING]: any
+	[ApplicationTag.ENUMERATED]:
+		| ObjectType
+		| EventState
+		| EngineeringUnits
+		| PropertyIdentifier
+		| DeviceStatus
+		| Segmentation
+		| Reliability
+	[ApplicationTag.DATE]: Date
+	[ApplicationTag.TIME]: Date
+	[ApplicationTag.OBJECTIDENTIFIER]: BACNetObjectID
+	[ApplicationTag.EMPTYLIST]: any
+	[ApplicationTag.WEEKNDAY]: any
+	[ApplicationTag.DATERANGE]: any
+	[ApplicationTag.DATETIME]: any
+	[ApplicationTag.TIMESTAMP]: BACNetTimestamp
+	[ApplicationTag.ERROR]: any
+	[ApplicationTag.DEVICE_OBJECT_PROPERTY_REFERENCE]: any
+	[ApplicationTag.DEVICE_OBJECT_REFERENCE]: any
+	[ApplicationTag.OBJECT_PROPERTY_REFERENCE]: any
+	[ApplicationTag.DESTINATION]: any
+	[ApplicationTag.RECIPIENT]: BACNetRecipient
+	[ApplicationTag.COV_SUBSCRIPTION]: BACNetCovSubscription
+	[ApplicationTag.CALENDAR_ENTRY]: any
+	[ApplicationTag.WEEKLY_SCHEDULE]: any
+	[ApplicationTag.SPECIAL_EVENT]: any
+	[ApplicationTag.READ_ACCESS_SPECIFICATION]: any
+	[ApplicationTag.READ_ACCESS_RESULT]: any
+	[ApplicationTag.LIGHTING_COMMAND]: any
+	[ApplicationTag.CONTEXT_SPECIFIC_DECODED]: any
+	[ApplicationTag.CONTEXT_SPECIFIC_ENCODED]: any
+	[ApplicationTag.LOG_RECORD]: any
 }
 
 export interface BACNetPropertyState {
@@ -122,9 +189,15 @@ export interface BACNetEventInformation {
 	eventPriorities: number[]
 }
 
-export interface BACNetTimestamp {
-	type: TimeStamp
-	value: any
+export interface BACNetTimestamp<T extends TimeStamp = TimeStamp> {
+	type: T
+	value: T extends TimeStamp.DATETIME
+		? Date
+		: T extends TimeStamp.SEQUENCE_NUMBER
+			? number
+			: T extends TimeStamp.TIME
+				? Date
+				: never
 }
 
 export interface Decode<T> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -197,13 +197,6 @@ export interface Calendar {
 	value: any[]
 }
 
-export interface AppData {
-	len: number
-	type: ApplicationTag
-	value: any
-	encoding?: number
-}
-
 export interface DeviceObjPropertyRef {
 	len: number
 	value: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,8 +157,8 @@ export interface ApplicationTagValueTypeMap {
 	[ApplicationTag.DATETIME]: any
 	[ApplicationTag.TIMESTAMP]: BACNetTimestamp
 	[ApplicationTag.ERROR]: any
-	[ApplicationTag.DEVICE_OBJECT_PROPERTY_REFERENCE]: any
-	[ApplicationTag.DEVICE_OBJECT_REFERENCE]: any
+	[ApplicationTag.DEVICE_OBJECT_PROPERTY_REFERENCE]: DeviceObjPropertyRef
+	[ApplicationTag.DEVICE_OBJECT_REFERENCE]: BACNetDevObjRef
 	[ApplicationTag.OBJECT_PROPERTY_REFERENCE]: any
 	[ApplicationTag.DESTINATION]: any
 	[ApplicationTag.RECIPIENT]: BACNetRecipient


### PR DESCRIPTION
The goal of this PR is to lay solid foundations and pave the way for future work on making `ApplicationData` values type-safe, as discussed in #31 .

The strategy for doing this revolves around the new `ApplicationTagValueTypeMap` interface, which maps Application Tag to the value types expected by the (de)serialization code in [`src/asn1.ts`](https://github.com/innovation-system/node-bacnet/blob/master/src/lib/asn1.ts) and in the files within the [`src/lib/services`](https://github.com/innovation-system/node-bacnet/tree/master/src/lib/services) folder.

Note that one Application Tag might map to more than one value type, such as in the case of the `ApplicationTag.ENUMERATED` tag which applies to any of the enumerations supported by the protocol. In order to handle this use case, the `BACNetAppData` accepts two generic parameters, one for the Application Tag and one (optional) for the allowed TS type (which must be a subset of those mapped to the Application Tag).

This PR should be non-breaking in that:

1) Any Application Tag for which a type hasn't been defined yet is mapped to `any`
2) Any violation of a type that has already been defined can be considered a bug as type definitions are based on the assumptions made throughout the rest of this library's codebase