### PR TITLE
chore: add CLAUDE.md referencing shared copilot instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
+
+## Project Instructions
+
+All coding standards, architecture patterns, testing guidelines, and contribution requirements are maintained in a single shared location:
+
+**[.github/copilot-instructions.md](.github/copilot-instructions.md)**
+
+That file is the primary reference for:
+
+- Code style and TypeScript conventions
+- Architecture patterns (event-driven design, buffer management, ASN.1 encoding)
+- BACnet protocol specifics
+- Testing strategy and coverage requirements
+- Git workflow and conventional commits
+- Pull request quality standards
+
+## Quick Reference
+
+```bash
+# Build
+npm run build
+
+# Lint
+npm run lint
+npm run lint:fix
+
+# Test
+npm run test:all           # Run all tests
+npm run test:unit          # Unit tests only
+npm run test:integration   # Integration tests only
+npm run test:compliance    # Compliance tests only
+
+# Development
+npm run emulator:start     # Start BACnet device emulator
+npm run docs               # Generate API docs with TypeDoc
+```


### PR DESCRIPTION
## Summary

- Adds a `CLAUDE.md` file that points to `.github/copilot-instructions.md` as the single source of truth for project guidelines
- Includes only a minimal quick-reference section with essential commands (`build`, `lint`, `test`, `emulator`)
- Avoids duplicating any content already covered in the copilot instructions

## Rationale

Rather than maintaining two separate instruction files with overlapping content, this approach keeps `.github/copilot-instructions.md` as the authoritative reference and has `CLAUDE.md` simply redirect to it. This ensures consistency and reduces maintenance burden.

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Verify the relative link to `.github/copilot-instructions.md` resolves properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)