### PR TITLE
fix(services): map eventNotify to EventNotifyData decoder

### DIFF
--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -85,6 +85,7 @@ const ServicesMap: Record<
 	deviceCommunicationControl: DeviceCommunicationControl,
 	error: ErrorService,
 	eventInformation: EventInformation,
+	eventNotify: EventNotifyData,
 	eventNotifyData: EventNotifyData,
 	getEnrollmentSummary: GetEnrollmentSummary,
 	getEventInformation: GetEventInformation,


### PR DESCRIPTION
## Summary
Adds an explicit `eventNotify` mapping in `ServicesMap` so Confirmed Event Notification packets are decoded with `EventNotifyData`.

## Problem
`eventNotify` requests were not explicitly mapped in `src/lib/services/index.ts`, which could result in incomplete/missing decoded payload fields downstream (e.g. alarm/event handling relying on decoded object identifiers and notification fields).

## Change
- File: `src/lib/services/index.ts`
- Added one line in `ServicesMap`:
  - `eventNotify: EventNotifyData,`

## Impact
- Ensures `eventNotify` uses the correct decoder path.
- No changes to other BACnet services.
- Minimal footprint (1 file, 1 line).

## Validation
- Confirmed service dispatch now resolves `eventNotify` to `EventNotifyData`.
- Confirmed downstream event handling receives decoded payload structure.

## Compatibility
- Backward compatible.
- No API changes.