### PR TITLE
fix(segmentation): correctly reassemble segmented ComplexACK responses

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -361,7 +361,7 @@ export default class BACnetClient extends TypedEventEmitter<BACnetClientEvents> 
 		if (!moreFollows) {
 			const apduBuffer = Buffer.concat(this._segmentStore)
 			this._segmentStore = []
-			msg.type &= ~PduConReqBit.SEGMENTED_MESSAGE
+			msg.header.apduType &= ~PduConReqBit.SEGMENTED_MESSAGE
 			this._handlePdu(apduBuffer, 0, apduBuffer.length, msg.header)
 		}
 	}
@@ -589,7 +589,7 @@ export default class BACnetClient extends TypedEventEmitter<BACnetClientEvents> 
 								| ConfirmedServiceRequestMessage
 								| ComplexAckMessage
 							),
-						true,
+						false,
 						buffer,
 						offset + msg.len,
 						length - msg.len,


### PR DESCRIPTION
## Summary
This PR fixes segmented response handling for BACnet `ComplexACK` messages.

## Problem
Some devices return segmented `ComplexACK` responses (e.g. large object/property payloads).  
The client could enter an invalid APDU state during reassembly, resulting in abort/error behavior and missing response payload.

## Root Cause
Segment flags/state were not handled consistently across segmented frames and final reassembled APDU processing.

## Changes
- Correct segmented `ComplexACK` reassembly flow.
- Clear segmented state/flags after full APDU is reassembled.
- Ensure final payload is passed once through normal decode path after reassembly.

## Impact
- Stabilizes reads from devices that require segmentation.
- Prevents invalid state transitions/abort loops in segmented exchanges.
- Improves compatibility with larger BACnet payloads.

## Validation
- Verified against real-device traffic with segmented `ComplexACK`.
- Confirmed reassembled response is decoded successfully.
- Confirmed no regression for non-segmented responses.

## Compatibility
Backward compatible.  
No API changes.