### PR TITLE
fix: uses appropriate typings for property read/write request payloads

### DIFF
--- a/src/lib/EventTypes.ts
+++ b/src/lib/EventTypes.ts
@@ -28,6 +28,8 @@ import {
 	BACNetObjectID,
 	BACNetPropertyID,
 	BACNetAppData,
+	WritePropertyRequest,
+	ReadPropertyRequest,
 } from './types'
 
 export type Constructor<T = object> = new (...args: any[]) => T
@@ -74,22 +76,12 @@ export interface BaseEventContent {
 
 // These more specific interfaces help TypeScript provide better IntelliSense
 export interface ReadPropertyContent extends BaseEventContent {
-	payload: {
-		objectId: BACNetObjectID
-		property: BACNetPropertyID
-	}
+	payload: ReadPropertyRequest
 	address?: string
 }
 
 export interface WritePropertyContent extends BaseEventContent {
-	payload: {
-		objectId: BACNetObjectID
-		property?: BACNetPropertyID
-		value?: {
-			property?: BACNetPropertyID
-			value?: BACNetAppData | BACNetAppData[]
-		}
-	}
+	payload: WritePropertyRequest
 }
 
 export interface ReadPropertyMultipleContent extends BaseEventContent {


### PR DESCRIPTION
This PR fixes a mistyping affecting read/write request payloads. For some reason, the payloads of events modelling read/write requests had been defined separately and independently of the payload actually returned by the .decode() function of the service handler matching the incoming request.

See src/lib/client.ts@530 for the parser invocation
See src/lib/client.ts@557 for triggering of service request events

I need this to surface the `priority` value at the typings level, so that I may use it to address https://github.com/bacnet-js/device/issues/32 .